### PR TITLE
Fix a bug in accuracy computation and make apply_attention nicer.

### DIFF
--- a/train.py
+++ b/train.py
@@ -74,7 +74,9 @@ def run(net, loader, optimizer, tracker, train=False, prefix='', epoch=0):
             idxs.append(idx.view(-1).clone())
 
         loss_tracker.append(loss.data[0])
-        acc_tracker.append(acc.mean())
+        # acc_tracker.append(acc.mean())
+        for a in acc:
+            acc_tracker.append(a.item())
         fmt = '{:.4f}'.format
         tq.set_postfix(loss=fmt(loss_tracker.mean.value), acc=fmt(acc_tracker.mean.value))
 


### PR DESCRIPTION
The accuracy from the computation of the acc_tracker is slightly better than that of the official evaluation method. One reason for this is the overall accuracy is not constant with the mean of all the accuracy from each sample when the number of all samples cannot be divided by batch_size.

For example, Let's suppose there are 7 samples and the batch_size is 3. The corresponding accuracy is [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.3]. Following the accuracy computation in this code, the overall accuracy is (0.1+0.1+0.3)/3=5/30=1/6. However, the correct overall accuracy should be (0.1*6+0.3)/7=9/70. This could result the former being larger than the latter.