### PR TITLE
depreciated xavier uniform method

### DIFF
--- a/model.py
+++ b/model.py
@@ -87,7 +87,7 @@ class TextProcessor(nn.Module):
 
     def _init_lstm(self, weight):
         for w in weight.chunk(4, 0):
-            init.xavier_uniform(w)
+            init.xavier_uniform_(w)
 
     def forward(self, q, q_len):
         embedded = self.embedding(q)


### PR DESCRIPTION
xavier_uniform is depreciated and throws a warning

new method xavier_uniform_ should be used